### PR TITLE
Allow to redirect to a custom URL after logout.

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -405,6 +405,8 @@ local function openidc_logout(opts, session)
     ngx.print(openidc_transparent_pixel)
     ngx.exit(ngx.OK)
     return
+  elseif opts.redirect_after_logout_uri then
+    return ngx.redirect(opts.redirect_after_logout_uri)
   elseif opts.discovery.end_session_endpoint then
     return ngx.redirect(opts.discovery.end_session_endpoint)
   elseif opts.discovery.ping_end_session_endpoint then


### PR DESCRIPTION
This is used when the discovery does not have a redirect set,
or when you want to override the discovered URL from the RP side